### PR TITLE
alternative to decimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,26 @@ go get -u github.com/EasyGolang/goTools
 ## 包的主页
 
 https://pkg.go.dev/github.com/EasyGolang/goTools
+
+
+### Decimal替代方案 cDec
+
+#### 测试用例
+```
+go test ./cDec
+```
+
+#### 使用示例
+```
+// 将一个浮点字符串，转换成value，并进行运算求值（更多示例可以看单元测试）
+floatStr1 := "0.00012345"
+floatStr2 := "1.5"
+a1 := cDec.NewFromString(floatStr1)
+a2 := cDec.NewFromString(floatStr2)
+
+a3 := a1.Sub(a2)
+a4 := a1.Mul(a2)
+a5 := a1.Add(a2)
+a6 := a1.Div(a2)
+...
+```

--- a/cDec/const.go
+++ b/cDec/const.go
@@ -1,0 +1,7 @@
+package cDec
+
+var (
+	Two   Value = NewFromInt(2)
+	Three Value = NewFromInt(3)
+	Four  Value = NewFromInt(4)
+)

--- a/cDec/convert.go
+++ b/cDec/convert.go
@@ -1,0 +1,613 @@
+//go:build !dnum
+// +build !dnum
+
+package cDec
+
+import (
+	"bytes"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"sync/atomic"
+)
+
+const MaxPrecision = 12
+const DefaultPrecision = 8
+
+const DefaultPow = 1e8
+
+type Value int64
+
+const Zero = Value(0)
+const One = Value(1e8)
+const NegOne = Value(-1e8)
+const PosInf = Value(math.MaxInt64)
+const NegInf = Value(math.MinInt64)
+
+type RoundingMode int
+
+const (
+	Up RoundingMode = iota
+	Down
+	HalfUp
+)
+
+// Trunc returns the integer portion (truncating any fractional part)
+func (v Value) Trunc() Value {
+	return NewFromFloat(math.Floor(v.Float64()))
+}
+
+func (v Value) Round(r int, mode RoundingMode) Value {
+	pow := math.Pow10(r)
+	f := v.Float64() * pow
+	switch mode {
+	case Up:
+		f = math.Ceil(f) / pow
+	case HalfUp:
+		f = math.Floor(f+0.5) / pow
+	case Down:
+		f = math.Floor(f) / pow
+	}
+
+	s := strconv.FormatFloat(f, 'f', r, 64)
+	return MustNewFromString(s)
+}
+
+func (v Value) Value() (driver.Value, error) {
+	return v.Float64(), nil
+}
+
+func (v *Value) Scan(src interface{}) error {
+	switch d := src.(type) {
+	case int64:
+		*v = NewFromInt(d)
+		return nil
+
+	case float64:
+		*v = NewFromFloat(d)
+		return nil
+
+	case []byte:
+		vv, err := NewFromString(string(d))
+		if err != nil {
+			return err
+		}
+		*v = vv
+		return nil
+
+	default:
+
+	}
+
+	return fmt.Errorf("fixedpoint.Value scan error, type: %T is not supported, value; %+v", src, src)
+}
+
+func (v Value) Float64() float64 {
+	if v == PosInf {
+		return math.Inf(1)
+	} else if v == NegInf {
+		return math.Inf(-1)
+	}
+	return float64(v) / DefaultPow
+}
+
+func (v Value) Abs() Value {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func (v Value) String() string {
+	if v == PosInf {
+		return "inf"
+	} else if v == NegInf {
+		return "-inf"
+	}
+	return strconv.FormatFloat(float64(v)/DefaultPow, 'f', -1, 64)
+}
+
+func (v Value) FormatString(prec int) string {
+	if v == PosInf {
+		return "inf"
+	} else if v == NegInf {
+		return "-inf"
+	}
+
+	u := int64(v)
+
+	// trunc precision
+	precDiff := DefaultPrecision - prec
+	if precDiff > 0 {
+		powDiff := int64(math.Round(math.Pow10(precDiff)))
+		u = int64(v) / powDiff * powDiff
+	}
+
+	// check sign
+	sign := Value(u).Sign()
+
+	basePow := int64(DefaultPow)
+	a := u / basePow
+	b := u % basePow
+
+	if a < 0 {
+		a = -a
+	}
+
+	if b < 0 {
+		b = -b
+	}
+
+	str := strconv.FormatInt(a, 10)
+	if prec > 0 {
+		bStr := fmt.Sprintf(".%08d", b)
+		if prec <= DefaultPrecision {
+			bStr = bStr[0 : prec+1]
+		} else {
+			for i := prec - DefaultPrecision; i > 0; i-- {
+				bStr += "0"
+			}
+		}
+
+		str += bStr
+	}
+
+	if sign < 0 {
+		str = "-" + str
+	}
+
+	return str
+}
+
+func (v Value) Percentage() string {
+	if v == 0 {
+		return "0"
+	}
+	if v == PosInf {
+		return "inf%"
+	} else if v == NegInf {
+		return "-inf%"
+	}
+	return strconv.FormatFloat(float64(v)/DefaultPow*100., 'f', -1, 64) + "%"
+}
+
+func (v Value) FormatPercentage(prec int) string {
+	if v == 0 {
+		return "0"
+	}
+	if v == PosInf {
+		return "inf%"
+	} else if v == NegInf {
+		return "-inf%"
+	}
+	pow := math.Pow10(prec)
+	result := strconv.FormatFloat(
+		math.Trunc(float64(v)/DefaultPow*pow*100.)/pow, 'f', prec, 64)
+	return result + "%"
+}
+
+func (v Value) SignedPercentage() string {
+	if v > 0 {
+		return "+" + v.Percentage()
+	}
+	return v.Percentage()
+}
+
+func (v Value) Int64() int64 {
+	return int64(v.Float64())
+}
+
+func (v Value) Int() int {
+	n := v.Int64()
+	if int64(int(n)) != n {
+		panic("unable to convert Value to int32")
+	}
+	return int(n)
+}
+
+func (v Value) Neg() Value {
+	return -v
+}
+
+// TODO inf
+func (v Value) Sign() int {
+	if v > 0 {
+		return 1
+	} else if v == 0 {
+		return 0
+	} else {
+		return -1
+	}
+}
+
+func (v Value) IsZero() bool {
+	return v == 0
+}
+
+func Mul(x, y Value) Value {
+	return NewFromFloat(x.Float64() * y.Float64())
+}
+
+func (v Value) Mul(v2 Value) Value {
+	return NewFromFloat(v.Float64() * v2.Float64())
+}
+
+func Div(x, y Value) Value {
+	return NewFromFloat(x.Float64() / y.Float64())
+}
+
+func (v Value) Div(v2 Value) Value {
+	return NewFromFloat(v.Float64() / v2.Float64())
+}
+
+func (v Value) Floor() Value {
+	return NewFromFloat(math.Floor(v.Float64()))
+}
+
+func (v Value) Ceil() Value {
+	return NewFromFloat(math.Ceil(v.Float64()))
+}
+
+func (v Value) Sub(v2 Value) Value {
+	return Value(int64(v) - int64(v2))
+}
+
+func (v Value) Add(v2 Value) Value {
+	return Value(int64(v) + int64(v2))
+}
+
+func (v *Value) AtomicAdd(v2 Value) {
+	atomic.AddInt64((*int64)(v), int64(v2))
+}
+
+func (v *Value) AtomicLoad() Value {
+	i := atomic.LoadInt64((*int64)(v))
+	return Value(i)
+}
+
+func (v *Value) UnmarshalYAML(unmarshal func(a interface{}) error) (err error) {
+	var s string
+	if err = unmarshal(&s); err == nil {
+		nv, err2 := NewFromString(s)
+		if err2 == nil {
+			*v = nv
+			return
+		}
+	}
+
+	return err
+}
+
+func (v Value) MarshalYAML() (interface{}, error) {
+	return v.FormatString(DefaultPrecision), nil
+}
+
+func (v Value) MarshalJSON() ([]byte, error) {
+	if v.IsInf() {
+		return []byte("\"" + v.String() + "\""), nil
+	}
+	return []byte(v.FormatString(DefaultPrecision)), nil
+}
+
+func (v *Value) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(data, []byte{'n', 'u', 'l', 'l'}) {
+		*v = Zero
+		return nil
+	}
+	if len(data) == 0 {
+		*v = Zero
+		return nil
+	}
+	var err error
+	if data[0] == '"' {
+		data = data[1 : len(data)-1]
+	}
+	if *v, err = NewFromString(string(data)); err != nil {
+		return err
+	}
+	return nil
+}
+
+var ErrPrecisionLoss = errors.New("precision loss")
+
+func Parse(input string) (num int64, numDecimalPoints int, err error) {
+	length := len(input)
+	isPercentage := input[length-1] == '%'
+	if isPercentage {
+		length -= 1
+		input = input[0:length]
+	}
+
+	var neg int64 = 1
+	var digit int64
+	for i := 0; i < length; i++ {
+		c := input[i]
+		if c == '-' {
+			neg = -1
+		} else if c >= '0' && c <= '9' {
+			digit, err = strconv.ParseInt(string(c), 10, 64)
+			if err != nil {
+				return
+			}
+
+			num = num*10 + digit
+		} else if c == '.' {
+			i++
+			if i > len(input)-1 {
+				err = fmt.Errorf("expect fraction numbers after dot")
+				return
+			}
+
+			for j := i; j < len(input); j++ {
+				fc := input[j]
+				if fc >= '0' && fc <= '9' {
+					digit, err = strconv.ParseInt(string(fc), 10, 64)
+					if err != nil {
+						return
+					}
+
+					numDecimalPoints++
+					num = num*10 + digit
+
+					if numDecimalPoints >= MaxPrecision {
+						return num, numDecimalPoints, ErrPrecisionLoss
+					}
+				} else {
+					err = fmt.Errorf("expect digit, got %c", fc)
+					return
+				}
+			}
+			break
+		} else {
+			err = fmt.Errorf("unexpected char %c", c)
+			return
+		}
+	}
+
+	num = num * neg
+	if isPercentage {
+		numDecimalPoints += 2
+	}
+
+	return num, numDecimalPoints, nil
+}
+
+func NewFromString(input string) (Value, error) {
+	length := len(input)
+
+	if length == 0 {
+		return 0, nil
+	}
+
+	isPercentage := input[length-1] == '%'
+	if isPercentage {
+		input = input[0 : length-1]
+	}
+	dotIndex := -1
+	hasDecimal := false
+	decimalCount := 0
+	// if is decimal, we don't need this
+	hasScientificNotion := false
+	hasIChar := false
+	scIndex := -1
+	for i, c := range input {
+		if hasDecimal {
+			if c <= '9' && c >= '0' {
+				decimalCount++
+			} else {
+				break
+			}
+
+		} else if c == '.' {
+			dotIndex = i
+			hasDecimal = true
+		}
+		if c == 'e' || c == 'E' {
+			hasScientificNotion = true
+			scIndex = i
+			break
+		}
+		if c == 'i' || c == 'I' {
+			hasIChar = true
+			break
+		}
+	}
+	if hasDecimal {
+		after := input[dotIndex+1:]
+		if decimalCount >= 8 {
+			after = after[0:8] + "." + after[8:]
+		} else {
+			after = after[0:decimalCount] + strings.Repeat("0", 8-decimalCount) + after[decimalCount:]
+		}
+		input = input[0:dotIndex] + after
+		v, err := strconv.ParseFloat(input, 64)
+		if err != nil {
+			return 0, err
+		}
+
+		if isPercentage {
+			v = v * 0.01
+		}
+
+		return Value(int64(math.Trunc(v))), nil
+
+	} else if hasScientificNotion {
+		exp, err := strconv.ParseInt(input[scIndex+1:], 10, 32)
+		if err != nil {
+			return 0, err
+		}
+		v, err := strconv.ParseFloat(input[0:scIndex+1]+strconv.FormatInt(exp+8, 10), 64)
+		if err != nil {
+			return 0, err
+		}
+		return Value(int64(math.Trunc(v))), nil
+	} else if hasIChar {
+		if floatV, err := strconv.ParseFloat(input, 64); nil != err {
+			return 0, err
+		} else if math.IsInf(floatV, 1) {
+			return PosInf, nil
+		} else if math.IsInf(floatV, -1) {
+			return NegInf, nil
+		} else {
+			return 0, fmt.Errorf("fixedpoint.Value parse error, invalid input string %s", input)
+		}
+	} else {
+		v, err := strconv.ParseInt(input, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		if isPercentage {
+			v = v * DefaultPow / 100
+		} else {
+			v = v * DefaultPow
+		}
+		return Value(v), nil
+	}
+}
+
+func MustNewFromString(input string) Value {
+	v, err := NewFromString(input)
+	if err != nil {
+		panic(fmt.Errorf("can not parse %s into fixedpoint, error: %s", input, err.Error()))
+	}
+	return v
+}
+
+func NewFromBytes(input []byte) (Value, error) {
+	return NewFromString(string(input))
+}
+
+func MustNewFromBytes(input []byte) (v Value) {
+	var err error
+	if v, err = NewFromString(string(input)); err != nil {
+		return Zero
+	}
+	return v
+}
+
+func Must(v Value, err error) Value {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func NewFromFloat(val float64) Value {
+	if math.IsInf(val, 1) {
+		return PosInf
+	} else if math.IsInf(val, -1) {
+		return NegInf
+	}
+	return Value(int64(math.Trunc(val * DefaultPow)))
+}
+
+func NewFromInt(val int64) Value {
+	return Value(val * DefaultPow)
+}
+
+func (a Value) IsInf() bool {
+	return a == PosInf || a == NegInf
+}
+
+func (a Value) MulExp(exp int) Value {
+	return Value(int64(float64(a) * math.Pow(10, float64(exp))))
+}
+
+func (a Value) NumIntDigits() int {
+	digits := 0
+	target := int64(a)
+	for pow := int64(DefaultPow); pow <= target; pow *= 10 {
+		digits++
+	}
+	return digits
+}
+
+// TODO: speedup
+func (a Value) NumFractionalDigits() int {
+	if a == 0 {
+		return 0
+	}
+	numPow := 0
+	for pow := int64(DefaultPow); pow%10 != 1; pow /= 10 {
+		numPow++
+	}
+	numZeros := 0
+	for v := int64(a); v%10 == 0; v /= 10 {
+		numZeros++
+	}
+	return numPow - numZeros
+}
+
+func Compare(x, y Value) int {
+	if x > y {
+		return 1
+	} else if x == y {
+		return 0
+	} else {
+		return -1
+	}
+}
+
+func (x Value) Compare(y Value) int {
+	if x > y {
+		return 1
+	} else if x == y {
+		return 0
+	} else {
+		return -1
+	}
+}
+
+func Min(a, b Value) Value {
+	if a < b {
+		return a
+	}
+
+	return b
+}
+
+func Max(a, b Value) Value {
+	if a > b {
+		return a
+	}
+
+	return b
+}
+
+func Equal(x, y Value) bool {
+	return x == y
+}
+
+func (x Value) Eq(y Value) bool {
+	return x == y
+}
+
+func Abs(a Value) Value {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func Clamp(x, min, max Value) Value {
+	if x < min {
+		return min
+	}
+	if x > max {
+		return max
+	}
+	return x
+}
+
+func (x Value) Clamp(min, max Value) Value {
+	if x < min {
+		return min
+	}
+	if x > max {
+		return max
+	}
+	return x
+}

--- a/cDec/convert_test.go
+++ b/cDec/convert_test.go
@@ -1,0 +1,124 @@
+package cDec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_FormatString(t *testing.T) {
+	cases := []struct {
+		input    string
+		prec     int
+		expected string
+	}{
+		{input: "0.57", prec: 5, expected: "0.57000"},
+		{input: "-0.57", prec: 5, expected: "-0.57000"},
+		{input: "0.57123456", prec: 8, expected: "0.57123456"},
+		{input: "-0.57123456", prec: 8, expected: "-0.57123456"},
+		{input: "0.57123456", prec: 5, expected: "0.57123"},
+		{input: "-0.57123456", prec: 5, expected: "-0.57123"},
+		{input: "0.57123456", prec: 0, expected: "0"},
+		{input: "-0.57123456", prec: 0, expected: "0"},
+		{input: "0.57123456", prec: -1, expected: "0"},
+		{input: "-0.57123456", prec: -1, expected: "0"},
+		{input: "0.57123456", prec: -5, expected: "0"},
+		{input: "-0.57123456", prec: -5, expected: "0"},
+		{input: "0.57123456", prec: -9, expected: "0"},
+		{input: "-0.57123456", prec: -9, expected: "0"},
+
+		{input: "1.23456789", prec: 9, expected: "1.234567890"},
+		{input: "-1.23456789", prec: 9, expected: "-1.234567890"},
+		{input: "1.02345678", prec: 9, expected: "1.023456780"},
+		{input: "-1.02345678", prec: 9, expected: "-1.023456780"},
+		{input: "1.02345678", prec: 2, expected: "1.02"},
+		{input: "-1.02345678", prec: 2, expected: "-1.02"},
+		{input: "1.02345678", prec: 0, expected: "1"},
+		{input: "-1.02345678", prec: 0, expected: "-1"},
+		{input: "1.02345678", prec: -1, expected: "0"},
+		{input: "-1.02345678", prec: -1, expected: "0"},
+		{input: "1.02345678", prec: -10, expected: "0"},
+		{input: "-1.02345678", prec: -10, expected: "0"},
+
+		{input: "0.0001234", prec: 9, expected: "0.000123400"},
+		{input: "-0.0001234", prec: 9, expected: "-0.000123400"},
+		{input: "0.0001234", prec: 7, expected: "0.0001234"},
+		{input: "-0.0001234", prec: 7, expected: "-0.0001234"},
+		{input: "0.0001234", prec: 5, expected: "0.00012"},
+		{input: "-0.0001234", prec: 5, expected: "-0.00012"},
+		{input: "0.0001234", prec: 3, expected: "0.000"},
+		{input: "-0.0001234", prec: 3, expected: "0.000"},
+		{input: "0.0001234", prec: 2, expected: "0.00"},
+		{input: "-0.0001234", prec: 2, expected: "0.00"},
+		{input: "0.0001234", prec: 0, expected: "0"},
+		{input: "-0.0001234", prec: 0, expected: "0"},
+		{input: "0.00001234", prec: -1, expected: "0"},
+		{input: "-0.00001234", prec: -1, expected: "0"},
+		{input: "0.00001234", prec: -5, expected: "0"},
+		{input: "-0.00001234", prec: -5, expected: "0"},
+		{input: "0.00001234", prec: -9, expected: "0"},
+		{input: "-0.00001234", prec: -9, expected: "0"},
+
+		{input: "12.3456789", prec: 10, expected: "12.3456789000"},
+		{input: "-12.3456789", prec: 10, expected: "-12.3456789000"},
+		{input: "12.3456789", prec: 9, expected: "12.345678900"},
+		{input: "-12.3456789", prec: 9, expected: "-12.345678900"},
+		{input: "12.3456789", prec: 7, expected: "12.3456789"},
+		{input: "-12.3456789", prec: 7, expected: "-12.3456789"},
+		{input: "12.3456789", prec: 5, expected: "12.34567"},
+		{input: "-12.3456789", prec: 5, expected: "-12.34567"},
+		{input: "12.3456789", prec: 1, expected: "12.3"},
+		{input: "-12.3456789", prec: 1, expected: "-12.3"},
+		{input: "12.3456789", prec: 0, expected: "12"},
+		{input: "-12.3456789", prec: 0, expected: "-12"},
+		{input: "12.3456789", prec: -1, expected: "10"},
+		{input: "-12.3456789", prec: -1, expected: "-10"},
+		{input: "12.3456789", prec: -2, expected: "0"},
+		{input: "-12.3456789", prec: -2, expected: "0"},
+		{input: "12.3456789", prec: -3, expected: "0"},
+		{input: "-12.3456789", prec: -3, expected: "0"},
+
+		{input: "12345678.9", prec: 10, expected: "12345678.9000000000"},
+		{input: "-12345678.9", prec: 10, expected: "-12345678.9000000000"},
+		{input: "12345678.9", prec: 3, expected: "12345678.900"},
+		{input: "-12345678.9", prec: 3, expected: "-12345678.900"},
+		{input: "12345678.9", prec: 1, expected: "12345678.9"},
+		{input: "-12345678.9", prec: 1, expected: "-12345678.9"},
+		{input: "12345678.9", prec: 0, expected: "12345678"},
+		{input: "-12345678.9", prec: 0, expected: "-12345678"},
+		{input: "12345678.9", prec: -2, expected: "12345600"},
+		{input: "-12345678.9", prec: -2, expected: "-12345600"},
+		{input: "12345678.9", prec: -5, expected: "12300000"},
+		{input: "-12345678.9", prec: -5, expected: "-12300000"},
+		{input: "12345678.9", prec: -7, expected: "10000000"},
+		{input: "-12345678.9", prec: -7, expected: "-10000000"},
+		{input: "12345678.9", prec: -8, expected: "0"},
+		{input: "-12345678.9", prec: -8, expected: "0"},
+		{input: "12345678.9", prec: -10, expected: "0"},
+		{input: "-12345678.9", prec: -10, expected: "0"},
+
+		{input: "123000", prec: 7, expected: "123000.0000000"},
+		{input: "-123000", prec: 7, expected: "-123000.0000000"},
+		{input: "123000", prec: 2, expected: "123000.00"},
+		{input: "-123000", prec: 2, expected: "-123000.00"},
+		{input: "123000", prec: 0, expected: "123000"},
+		{input: "-123000", prec: 0, expected: "-123000"},
+		{input: "123000", prec: -1, expected: "123000"},
+		{input: "-123000", prec: -1, expected: "-123000"},
+		{input: "123000", prec: -5, expected: "100000"},
+		{input: "-123000", prec: -5, expected: "-100000"},
+		{input: "123000", prec: -6, expected: "0"},
+		{input: "-123000", prec: -6, expected: "0"},
+		{input: "123000", prec: -8, expected: "0"},
+		{input: "-123000", prec: -8, expected: "0"},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%s with prec = %d, expected %s", c.input, c.prec, c.expected), func(t *testing.T) {
+			v := MustNewFromString(c.input)
+			s := v.FormatString(c.prec)
+			assert.Equal(t, c.expected, s)
+		})
+	}
+}

--- a/cDec/dec.go
+++ b/cDec/dec.go
@@ -1,0 +1,1367 @@
+//go:build dnum
+
+package cDec
+
+import (
+	"bytes"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"math"
+	"math/bits"
+	"strconv"
+	"strings"
+)
+
+type Value struct {
+	coef uint64
+	sign int8
+	exp  int
+}
+
+const (
+	signPosInf = +2
+	signPos    = +1
+	signZero   = 0
+	signNeg    = -1
+	signNegInf = -2
+	coefMin    = 1000_0000_0000_0000
+	coefMax    = 9999_9999_9999_9999
+	digitsMax  = 16
+	shiftMax   = digitsMax - 1
+	// to switch between scientific notion and normal presentation format
+	maxLeadingZeros = 19
+)
+
+// common values
+var (
+	Zero   = Value{}
+	One    = Value{1000_0000_0000_0000, signPos, 1}
+	NegOne = Value{1000_0000_0000_0000, signNeg, 1}
+	PosInf = Value{1, signPosInf, 0}
+	NegInf = Value{1, signNegInf, 0}
+)
+
+var pow10f = [...]float64{
+	1,
+	10,
+	100,
+	1000,
+	10000,
+	100000,
+	1000000,
+	10000000,
+	100000000,
+	1000000000,
+	10000000000,
+	100000000000,
+	1000000000000,
+	10000000000000,
+	100000000000000,
+	1000000000000000,
+	10000000000000000,
+	100000000000000000,
+	1000000000000000000,
+	10000000000000000000,
+	100000000000000000000}
+
+var pow10 = [...]uint64{
+	1,
+	10,
+	100,
+	1000,
+	10000,
+	100000,
+	1000000,
+	10000000,
+	100000000,
+	1000000000,
+	10000000000,
+	100000000000,
+	1000000000000,
+	10000000000000,
+	100000000000000,
+	1000000000000000,
+	10000000000000000,
+	100000000000000000,
+	1000000000000000000}
+
+var halfpow10 = [...]uint64{
+	0,
+	5,
+	50,
+	500,
+	5000,
+	50000,
+	500000,
+	5000000,
+	50000000,
+	500000000,
+	5000000000,
+	50000000000,
+	500000000000,
+	5000000000000,
+	50000000000000,
+	500000000000000,
+	5000000000000000,
+	50000000000000000,
+	500000000000000000,
+	5000000000000000000}
+
+func min(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a int, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func (v Value) Value() (driver.Value, error) {
+	return v.Float64(), nil
+}
+
+// NewFromInt returns a Value for an int
+func NewFromInt(n int64) Value {
+	if n == 0 {
+		return Zero
+	}
+	// n0 := n
+	sign := int8(signPos)
+	if n < 0 {
+		n = -n
+		sign = signNeg
+	}
+	return newNoSignCheck(sign, uint64(n), digitsMax)
+}
+
+const log2of10 = 3.32192809488736234
+
+// NewFromFloat converts a float64 to a Value
+func NewFromFloat(f float64) Value {
+	switch {
+	case math.IsInf(f, +1):
+		return PosInf
+	case math.IsInf(f, -1):
+		return NegInf
+	case math.IsNaN(f):
+		panic("value.NewFromFloat can't convert NaN")
+	}
+
+	if f == 0 {
+		return Zero
+	}
+
+	sign := int8(signPos)
+	if f < 0 {
+		f = -f
+		sign = signNeg
+	}
+	n := uint64(f)
+	if float64(n) == f {
+		return newNoSignCheck(sign, n, digitsMax)
+	}
+	_, e := math.Frexp(f)
+	e = int(float32(e) / log2of10)
+	c := uint64(f/math.Pow10(e-16) + 0.5)
+	return newNoSignCheck(sign, c, e)
+}
+
+// Raw constructs a Value without normalizing - arguments must be valid.
+// Used by SuValue Unpack
+func Raw(sign int8, coef uint64, exp int) Value {
+	return Value{coef, sign, int(exp)}
+}
+
+func newNoSignCheck(sign int8, coef uint64, exp int) Value {
+	atmax := false
+	for coef > coefMax {
+		coef = (coef + 5) / 10
+		exp++
+		atmax = true
+	}
+
+	if !atmax {
+		p := maxShift(coef)
+		coef *= pow10[p]
+		exp -= p
+	}
+	return Value{coef, sign, exp}
+}
+
+// New constructs a Value, maximizing coef and handling exp out of range
+// Used to normalize results of operations
+func New(sign int8, coef uint64, exp int) Value {
+	if sign == 0 || coef == 0 {
+		return Zero
+	} else if sign == signPosInf {
+		return PosInf
+	} else if sign == signNegInf {
+		return NegInf
+	} else {
+		atmax := false
+		for coef > coefMax {
+			coef = (coef + 5) / 10
+			exp++
+			atmax = true
+		}
+
+		if !atmax {
+			p := maxShift(coef)
+			coef *= pow10[p]
+			exp -= p
+		}
+		return Value{coef, sign, exp}
+	}
+}
+
+func maxShift(x uint64) int {
+	i := ilog10(x)
+	if i > shiftMax {
+		return 0
+	}
+	return shiftMax - i
+}
+
+func ilog10(x uint64) int {
+	// based on Hacker's Delight
+	if x == 0 {
+		return 0
+	}
+	y := (19 * (63 - bits.LeadingZeros64(x))) >> 6
+	if y < 18 && x >= pow10[y+1] {
+		y++
+	}
+	return y
+}
+
+func Inf(sign int8) Value {
+	switch {
+	case sign < 0:
+		return NegInf
+	case sign > 0:
+		return PosInf
+	default:
+		return Zero
+	}
+}
+
+func (dn Value) FormatString(prec int) string {
+	if dn.sign == 0 {
+		if prec <= 0 {
+			return "0"
+		} else {
+			return "0." + strings.Repeat("0", prec)
+		}
+	}
+	sign := ""
+	if dn.sign < 0 {
+		sign = "-"
+	}
+	if dn.IsInf() {
+		return sign + "inf"
+	}
+	digits := getDigits(dn.coef)
+	nd := len(digits)
+	e := int(dn.exp) - nd
+	if -maxLeadingZeros <= dn.exp && dn.exp <= 0 {
+		if prec < 0 {
+			return "0"
+		}
+		// decimal to the left
+		if prec+e+nd > 0 {
+			return sign + "0." + strings.Repeat("0", -e-nd) + digits[:min(prec+e+nd, nd)] + strings.Repeat("0", max(0, prec-nd+e+nd))
+		} else if -e-nd > 0 && prec != 0 {
+			return "0." + strings.Repeat("0", min(prec, -e-nd))
+		} else {
+			return "0"
+		}
+	} else if -nd < e && e <= -1 {
+		// decimal within
+		dec := nd + e
+		if prec > 0 {
+			decimals := digits[dec:min(dec+prec, nd)]
+			return sign + digits[:dec] + "." + decimals + strings.Repeat("0", max(0, prec-len(decimals)))
+		} else if prec == 0 {
+			return sign + digits[:dec]
+		}
+
+		sigFigures := digits[0:max(dec+prec, 0)]
+		if len(sigFigures) == 0 {
+			return "0"
+		}
+
+		return sign + sigFigures + strings.Repeat("0", max(-prec, 0))
+
+	} else if 0 < dn.exp && dn.exp <= digitsMax {
+		// decimal to the right
+		if prec > 0 {
+			return sign + digits + strings.Repeat("0", e) + "." + strings.Repeat("0", prec)
+		} else if prec+e >= 0 {
+			return sign + digits + strings.Repeat("0", e)
+		} else {
+			if len(digits) <= -prec-e {
+				return "0"
+			}
+
+			return sign + digits[0:len(digits)+prec+e] + strings.Repeat("0", -prec)
+		}
+	} else {
+		// scientific notation
+		after := ""
+		if nd > 1 {
+			after = "." + digits[1:min(1+prec, nd)] + strings.Repeat("0", max(0, min(1+prec, nd)-1-prec))
+		}
+		return sign + digits[:1] + after + "e" + strconv.Itoa(int(dn.exp-1))
+	}
+}
+
+// String returns a string representation of the Value
+func (dn Value) String() string {
+	if dn.sign == 0 {
+		return "0"
+	}
+	sign := ""
+	if dn.sign < 0 {
+		sign = "-"
+	}
+	if dn.IsInf() {
+		return sign + "inf"
+	}
+	digits := getDigits(dn.coef)
+	nd := len(digits)
+	e := int(dn.exp) - nd
+	if -maxLeadingZeros <= dn.exp && dn.exp <= 0 {
+		// decimal to the left
+		return sign + "0." + strings.Repeat("0", -e-nd) + digits
+	} else if -nd < e && e <= -1 {
+		// decimal within
+		dec := nd + e
+		return sign + digits[:dec] + "." + digits[dec:]
+	} else if 0 < dn.exp && dn.exp <= digitsMax {
+		// decimal to the right
+		return sign + digits + strings.Repeat("0", e)
+	} else {
+		// scientific notation
+		after := ""
+		if nd > 1 {
+			after = "." + digits[1:]
+		}
+		return sign + digits[:1] + after + "e" + strconv.Itoa(int(dn.exp-1))
+	}
+}
+
+func (dn Value) Percentage() string {
+	if dn.sign == 0 {
+		return "0%"
+	}
+	sign := ""
+	if dn.sign < 0 {
+		sign = "-"
+	}
+	if dn.IsInf() {
+		return sign + "inf%"
+	}
+	digits := getDigits(dn.coef)
+	nd := len(digits)
+	e := int(dn.exp) - nd + 2
+
+	if -maxLeadingZeros <= dn.exp && dn.exp <= -2 {
+		// decimal to the left
+		return sign + "0." + strings.Repeat("0", -e-nd) + digits + "%"
+	} else if -nd < e && e <= -1 {
+		// decimal within
+		dec := nd + e
+		return sign + digits[:dec] + "." + digits[dec:] + "%"
+	} else if -2 < dn.exp && dn.exp <= digitsMax {
+		// decimal to the right
+		return sign + digits + strings.Repeat("0", e) + "%"
+	} else {
+		// scientific notation
+		after := ""
+		if nd > 1 {
+			after = "." + digits[1:]
+		}
+		return sign + digits[:1] + after + "e" + strconv.Itoa(int(dn.exp-1)) + "%"
+	}
+}
+
+func (dn Value) FormatPercentage(prec int) string {
+	if dn.sign == 0 {
+		if prec <= 0 {
+			return "0"
+		} else {
+			return "0." + strings.Repeat("0", prec)
+		}
+	}
+	sign := ""
+	if dn.sign < 0 {
+		sign = "-"
+	}
+	if dn.IsInf() {
+		return sign + "inf"
+	}
+	digits := getDigits(dn.coef)
+	nd := len(digits)
+	exp := dn.exp + 2
+	e := int(exp) - nd
+
+	if -maxLeadingZeros <= exp && exp <= 0 {
+		// decimal to the left
+		if prec+e+nd > 0 {
+			return sign + "0." + strings.Repeat("0", -e-nd) + digits[:min(prec+e+nd, nd)] + strings.Repeat("0", max(0, prec-nd+e+nd)) + "%"
+		} else if -e-nd > 0 {
+			return "0." + strings.Repeat("0", -e-nd) + "%"
+		} else {
+			return "0"
+		}
+	} else if -nd < e && e <= -1 {
+		// decimal within
+		dec := nd + e
+		decimals := digits[dec:min(dec+prec, nd)]
+		return sign + digits[:dec] + "." + decimals + strings.Repeat("0", max(0, prec-len(decimals))) + "%"
+	} else if 0 < exp && exp <= digitsMax {
+		// decimal to the right
+		if prec > 0 {
+			return sign + digits + strings.Repeat("0", e) + "." + strings.Repeat("0", prec) + "%"
+		} else {
+			return sign + digits + strings.Repeat("0", e) + "%"
+		}
+	} else {
+		// scientific notation
+		after := ""
+		if nd > 1 {
+			after = "." + digits[1:min(1+prec, nd)] + strings.Repeat("0", max(0, min(1+prec, nd)-1-prec))
+		}
+		return sign + digits[:1] + after + "e" + strconv.Itoa(int(exp-1)) + "%"
+	}
+}
+
+func (dn Value) SignedPercentage() string {
+	if dn.Sign() >= 0 {
+		return "+" + dn.Percentage()
+	}
+	return dn.Percentage()
+}
+
+// get digit length
+func (a Value) NumDigits() int {
+	i := shiftMax
+	coef := a.coef
+	nd := 0
+	for coef != 0 && coef < pow10[i] {
+		i--
+	}
+	for coef != 0 {
+		coef %= pow10[i]
+		i--
+		nd++
+	}
+	return nd
+}
+
+// alias of Exp
+func (a Value) NumIntDigits() int {
+	return a.exp
+}
+
+// get fractional digits
+func (a Value) NumFractionalDigits() int {
+	nd := a.NumDigits()
+	return nd - a.exp
+}
+
+func getDigits(coef uint64) string {
+	var digits [digitsMax]byte
+	i := shiftMax
+	nd := 0
+	for coef != 0 {
+		digits[nd] = byte('0' + (coef / pow10[i]))
+		coef %= pow10[i]
+		nd++
+		i--
+	}
+	return string(digits[:nd])
+}
+
+func (v *Value) Scan(src interface{}) error {
+	var err error
+	switch d := src.(type) {
+	case int64:
+		*v = NewFromInt(d)
+		return nil
+	case float64:
+		*v = NewFromFloat(d)
+		return nil
+	case []byte:
+		*v, err = NewFromString(string(d))
+		if err != nil {
+			return err
+		}
+		return nil
+	default:
+	}
+	return fmt.Errorf("fixedpoint.Value scan error, type %T is not supported, value: %+v", src, src)
+}
+
+// NewFromString parses a numeric string and returns a Value representation.
+func NewFromString(s string) (Value, error) {
+	length := len(s)
+	if length == 0 {
+		return Zero, nil
+	}
+	isPercentage := s[length-1] == '%'
+	if isPercentage {
+		s = s[:length-1]
+	}
+	r := &reader{s, 0}
+	sign := r.getSign()
+	if r.matchStrIgnoreCase("inf") {
+		return Inf(sign), nil
+	}
+	coef, exp := r.getCoef()
+	exp += r.getExp()
+	if r.len() != 0 { // didn't consume entire string
+		return Zero, errors.New("invalid number")
+	} else if coef == 0 || exp < math.MinInt8 {
+		return Zero, nil
+	} else if exp > math.MaxInt8 {
+		return Inf(sign), nil
+	}
+	if isPercentage {
+		exp -= 2
+	}
+	atmax := false
+	for coef > coefMax {
+		coef = (coef + 5) / 10
+		exp++
+		atmax = true
+	}
+
+	if !atmax {
+		p := maxShift(coef)
+		coef *= pow10[p]
+		exp -= p
+	}
+	// check(coefMin <= coef && coef <= coefMax)
+	return Value{coef, sign, exp}, nil
+}
+
+func MustNewFromString(input string) Value {
+	v, err := NewFromString(input)
+	if err != nil {
+		panic(fmt.Errorf("cannot parse %s into fixedpoint, error: %s", input, err.Error()))
+	}
+	return v
+}
+
+func NewFromBytes(s []byte) (Value, error) {
+	length := len(s)
+	if length == 0 {
+		return Zero, nil
+	}
+	isPercentage := s[length-1] == '%'
+	if isPercentage {
+		s = s[:length-1]
+	}
+	r := &readerBytes{s, 0}
+	sign := r.getSign()
+	if r.matchStrIgnoreCase("inf") {
+		return Inf(sign), nil
+	}
+	coef, exp := r.getCoef()
+	exp += r.getExp()
+	if r.len() != 0 { // didn't consume entire string
+		return Zero, errors.New("invalid number")
+	} else if coef == 0 || exp < math.MinInt8 {
+		return Zero, nil
+	} else if exp > math.MaxInt8 {
+		return Inf(sign), nil
+	}
+	if isPercentage {
+		exp -= 2
+	}
+	atmax := false
+	for coef > coefMax {
+		coef = (coef + 5) / 10
+		exp++
+		atmax = true
+	}
+
+	if !atmax {
+		p := maxShift(coef)
+		coef *= pow10[p]
+		exp -= p
+	}
+	// check(coefMin <= coef && coef <= coefMax)
+	return Value{coef, sign, exp}, nil
+}
+
+func MustNewFromBytes(input []byte) Value {
+	v, err := NewFromBytes(input)
+	if err != nil {
+		panic(fmt.Errorf("cannot parse %s into fixedpoint, error: %s", input, err.Error()))
+	}
+	return v
+}
+
+// TODO: refactor by interface
+
+type readerBytes struct {
+	s []byte
+	i int
+}
+
+func (r *readerBytes) cur() byte {
+	if r.i >= len(r.s) {
+		return 0
+	}
+	return byte(r.s[r.i])
+}
+
+func (r *readerBytes) prev() byte {
+	if r.i == 0 {
+		return 0
+	}
+	return byte(r.s[r.i-1])
+}
+
+func (r *readerBytes) len() int {
+	return len(r.s) - r.i
+}
+
+func (r *readerBytes) match(c byte) bool {
+	if r.cur() == c {
+		r.i++
+		return true
+	}
+	return false
+}
+
+func (r *readerBytes) matchDigit() bool {
+	c := r.cur()
+	if '0' <= c && c <= '9' {
+		r.i++
+		return true
+	}
+	return false
+}
+
+func (r *readerBytes) matchStrIgnoreCase(pre string) bool {
+	pre = strings.ToLower(pre)
+	boundary := r.i + len(pre)
+	if boundary > len(r.s) {
+		return false
+	}
+	for i, c := range bytes.ToLower(r.s[r.i:boundary]) {
+		if pre[i] != c {
+			return false
+		}
+	}
+	r.i = boundary
+	return true
+}
+
+func (r *readerBytes) getSign() int8 {
+	if r.match('-') {
+		return int8(signNeg)
+	}
+	r.match('+')
+	return int8(signPos)
+}
+
+func (r *readerBytes) getCoef() (uint64, int) {
+	digits := false
+	beforeDecimal := true
+	for r.match('0') {
+		digits = true
+	}
+	if r.cur() == '.' && r.len() > 1 {
+		digits = false
+	}
+	n := uint64(0)
+	exp := 0
+	p := shiftMax
+	for {
+		c := r.cur()
+		if r.matchDigit() {
+			digits = true
+			// ignore extra decimal places
+			if c != '0' && p >= 0 {
+				n += uint64(c-'0') * pow10[p]
+			}
+			p--
+		} else if beforeDecimal {
+			// decimal point or end
+			exp = shiftMax - p
+			if !r.match('.') {
+				break
+			}
+			beforeDecimal = false
+			if !digits {
+				for r.match('0') {
+					digits = true
+					exp--
+				}
+			}
+		} else {
+			break
+		}
+	}
+	if !digits {
+		panic("numbers require at least one digit")
+	}
+	return n, exp
+}
+
+func (r *readerBytes) getExp() int {
+	e := 0
+	if r.match('e') || r.match('E') {
+		esign := r.getSign()
+		for r.matchDigit() {
+			e = e*10 + int(r.prev()-'0')
+		}
+		e *= int(esign)
+	}
+	return e
+}
+
+type reader struct {
+	s string
+	i int
+}
+
+func (r *reader) cur() byte {
+	if r.i >= len(r.s) {
+		return 0
+	}
+	return byte(r.s[r.i])
+}
+
+func (r *reader) prev() byte {
+	if r.i == 0 {
+		return 0
+	}
+	return byte(r.s[r.i-1])
+}
+
+func (r *reader) len() int {
+	return len(r.s) - r.i
+}
+
+func (r *reader) match(c byte) bool {
+	if r.cur() == c {
+		r.i++
+		return true
+	}
+	return false
+}
+
+func (r *reader) matchDigit() bool {
+	c := r.cur()
+	if '0' <= c && c <= '9' {
+		r.i++
+		return true
+	}
+	return false
+}
+
+func (r *reader) matchStrIgnoreCase(pre string) bool {
+	boundary := r.i + len(pre)
+	if boundary > len(r.s) {
+		return false
+	}
+	data := strings.ToLower(r.s[r.i:boundary])
+	pre = strings.ToLower(pre)
+	if data == pre {
+		r.i = boundary
+		return true
+	}
+	return false
+}
+
+func (r *reader) getSign() int8 {
+	if r.match('-') {
+		return int8(signNeg)
+	}
+	r.match('+')
+	return int8(signPos)
+}
+
+func (r *reader) getCoef() (uint64, int) {
+	digits := false
+	beforeDecimal := true
+	for r.match('0') {
+		digits = true
+	}
+	if r.cur() == '.' && r.len() > 1 {
+		digits = false
+	}
+	n := uint64(0)
+	exp := 0
+	p := shiftMax
+	for {
+		c := r.cur()
+		if r.matchDigit() {
+			digits = true
+			// ignore extra decimal places
+			if c != '0' && p >= 0 {
+				n += uint64(c-'0') * pow10[p]
+			}
+			p--
+		} else if beforeDecimal {
+			// decimal point or end
+			exp = shiftMax - p
+			if !r.match('.') {
+				break
+			}
+			beforeDecimal = false
+			if !digits {
+				for r.match('0') {
+					digits = true
+					exp--
+				}
+			}
+		} else {
+			break
+		}
+	}
+	if !digits {
+		panic("numbers require at least one digit")
+	}
+	return n, exp
+}
+
+func (r *reader) getExp() int {
+	e := 0
+	if r.match('e') || r.match('E') {
+		esign := r.getSign()
+		for r.matchDigit() {
+			e = e*10 + int(r.prev()-'0')
+		}
+		e *= int(esign)
+	}
+	return e
+}
+
+// end of FromStr ---------------------------------------------------
+
+// IsInf returns true if a Value is positive or negative infinite
+func (dn Value) IsInf() bool {
+	return dn.sign == signPosInf || dn.sign == signNegInf
+}
+
+// IsZero returns true if a Value is zero
+func (dn Value) IsZero() bool {
+	return dn.sign == signZero
+}
+
+// Float64 converts a Value to float64
+func (dn Value) Float64() float64 {
+	if dn.IsInf() {
+		return math.Inf(int(dn.sign))
+	}
+	g := float64(dn.coef)
+	if dn.sign == signNeg {
+		g = -g
+	}
+	i := int(dn.exp) - digitsMax
+	return g * math.Pow(10, float64(i))
+}
+
+// Int64 converts a Value to an int64, returning whether it was convertible
+func (dn Value) Int64() int64 {
+	if dn.sign == 0 {
+		return 0
+	}
+	if dn.sign != signNegInf && dn.sign != signPosInf {
+		if 0 < dn.exp && dn.exp < digitsMax {
+			return int64(dn.sign) * int64(dn.coef/pow10[digitsMax-dn.exp])
+		} else if dn.exp <= 0 && dn.coef != 0 {
+			result := math.Log10(float64(dn.coef)) - float64(digitsMax) + float64(dn.exp)
+			return int64(dn.sign) * int64(math.Pow(10, result))
+		}
+		if dn.exp == digitsMax {
+			return int64(dn.sign) * int64(dn.coef)
+		}
+		if dn.exp == digitsMax+1 {
+			return int64(dn.sign) * (int64(dn.coef) * 10)
+		}
+		if dn.exp == digitsMax+2 {
+			return int64(dn.sign) * (int64(dn.coef) * 100)
+		}
+		if dn.exp == digitsMax+3 && dn.coef < math.MaxInt64/1000 {
+			return int64(dn.sign) * (int64(dn.coef) * 1000)
+		}
+	}
+	panic("unable to convert Value to int64")
+}
+
+func (dn Value) Int() int {
+	// if int is int64, this is a nop
+	n := dn.Int64()
+	if int64(int(n)) != n {
+		panic("unable to convert Value to int32")
+	}
+	return int(n)
+}
+
+// Sign returns -1 for negative, 0 for zero, and +1 for positive
+func (dn Value) Sign() int {
+	return int(dn.sign)
+}
+
+// Coef returns the coefficient
+func (dn Value) Coef() uint64 {
+	return dn.coef
+}
+
+// Exp returns the exponent
+func (dn Value) Exp() int {
+	return int(dn.exp)
+}
+
+// Frac returns the fractional portion, i.e. x - x.Int()
+func (dn Value) Frac() Value {
+	if dn.sign == 0 || dn.sign == signNegInf || dn.sign == signPosInf ||
+		dn.exp >= digitsMax {
+		return Zero
+	}
+	if dn.exp <= 0 {
+		return dn
+	}
+	frac := dn.coef % pow10[digitsMax-dn.exp]
+	if frac == dn.coef {
+		return dn
+	}
+	return New(dn.sign, frac, int(dn.exp))
+}
+
+type RoundingMode int
+
+const (
+	Up RoundingMode = iota
+	Down
+	HalfUp
+)
+
+// Trunc returns the integer portion (truncating any fractional part)
+func (dn Value) Trunc() Value {
+	return dn.integer(Down)
+}
+
+func (dn Value) integer(mode RoundingMode) Value {
+	if dn.sign == 0 || dn.sign == signNegInf || dn.sign == signPosInf ||
+		dn.exp >= digitsMax {
+		return dn
+	}
+	if dn.exp <= 0 {
+		if mode == Up ||
+			(mode == HalfUp && dn.exp == 0 && dn.coef >= One.coef*5) {
+			return New(dn.sign, One.coef, int(dn.exp)+1)
+		}
+		return Zero
+	}
+	e := digitsMax - dn.exp
+	frac := dn.coef % pow10[e]
+	if frac == 0 {
+		return dn
+	}
+	i := dn.coef - frac
+	if (mode == Up && frac > 0) || (mode == HalfUp && frac >= halfpow10[e]) {
+		return New(dn.sign, i+pow10[e], int(dn.exp)) // normalize
+	}
+	return Value{i, dn.sign, dn.exp}
+}
+
+func (dn Value) Floor() Value {
+	return dn.Round(0, Down)
+}
+
+func (dn Value) Round(r int, mode RoundingMode) Value {
+	if dn.sign == 0 || dn.sign == signNegInf || dn.sign == signPosInf ||
+		r >= digitsMax {
+		return dn
+	}
+	if r <= -digitsMax {
+		return Zero
+	}
+	n := New(dn.sign, dn.coef, int(dn.exp)+r) // multiply by 10^r
+	n = n.integer(mode)
+	if n.sign == signPos || n.sign == signNeg { // i.e. not zero or inf
+		return New(n.sign, n.coef, int(n.exp)-r)
+	}
+	return n
+}
+
+// arithmetic operations -------------------------------------------------------
+
+// Neg returns the Value negated i.e. sign reversed
+func (dn Value) Neg() Value {
+	return Value{dn.coef, -dn.sign, dn.exp}
+}
+
+// Abs returns the Value with a positive sign
+func (dn Value) Abs() Value {
+	if dn.sign < 0 {
+		return Value{dn.coef, -dn.sign, dn.exp}
+	}
+	return dn
+}
+
+// Equal returns true if two Value's are equal
+func Equal(x, y Value) bool {
+	return x.sign == y.sign && x.exp == y.exp && x.coef == y.coef
+}
+
+func (x Value) Eq(y Value) bool {
+	return Equal(x, y)
+}
+
+func Max(x, y Value) Value {
+	if Compare(x, y) > 0 {
+		return x
+	}
+	return y
+}
+
+func Min(x, y Value) Value {
+	if Compare(x, y) < 0 {
+		return x
+	}
+	return y
+}
+
+// Compare compares two Value's returning -1 for <, 0 for ==, +1 for >
+func Compare(x, y Value) int {
+	switch {
+	case x.sign < y.sign:
+		return -1
+	case x.sign > y.sign:
+		return 1
+	case x == y:
+		return 0
+	}
+	sign := int(x.sign)
+	switch {
+	case sign == 0 || sign == signNegInf || sign == signPosInf:
+		return 0
+	case x.exp < y.exp:
+		return -sign
+	case x.exp > y.exp:
+		return +sign
+	case x.coef < y.coef:
+		return -sign
+	case x.coef > y.coef:
+		return +sign
+	default:
+		return 0
+	}
+}
+
+func (x Value) Compare(y Value) int {
+	return Compare(x, y)
+}
+
+func (v Value) MarshalYAML() (interface{}, error) {
+	return v.FormatString(8), nil
+}
+
+func (v *Value) UnmarshalYAML(unmarshal func(a interface{}) error) (err error) {
+	var f float64
+	if err = unmarshal(&f); err == nil {
+		*v = NewFromFloat(f)
+		return
+	}
+	var i int64
+	if err = unmarshal(&i); err == nil {
+		*v = NewFromInt(i)
+		return
+	}
+
+	var s string
+	if err = unmarshal(&s); err == nil {
+		nv, err2 := NewFromString(s)
+		if err2 == nil {
+			*v = nv
+			return
+		}
+	}
+	return err
+}
+
+// FIXME: should we limit to 8 prec?
+func (v Value) MarshalJSON() ([]byte, error) {
+	if v.IsInf() {
+		return []byte("\"" + v.String() + "\""), nil
+	}
+	return []byte(v.FormatString(8)), nil
+}
+
+func (v *Value) UnmarshalJSON(data []byte) error {
+	// FIXME: do we need to compare {}, [], "", or "null"?
+	if bytes.Compare(data, []byte{'n', 'u', 'l', 'l'}) == 0 {
+		*v = Zero
+		return nil
+	}
+	if len(data) == 0 {
+		*v = Zero
+		return nil
+	}
+	var err error
+	if data[0] == '"' {
+		data = data[1 : len(data)-1]
+	}
+	if *v, err = NewFromBytes(data); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Must(v Value, err error) Value {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// v * 10^(exp)
+func (v Value) MulExp(exp int) Value {
+	return Value{v.coef, v.sign, v.exp + exp}
+}
+
+// Sub returns the difference of two Value's
+func Sub(x, y Value) Value {
+	return Add(x, y.Neg())
+}
+
+func (x Value) Sub(y Value) Value {
+	return Sub(x, y)
+}
+
+// Add returns the sum of two Value's
+func Add(x, y Value) Value {
+	switch {
+	case x.sign == signZero:
+		return y
+	case y.sign == signZero:
+		return x
+	case x.IsInf():
+		if y.sign == -x.sign {
+			return Zero
+		}
+		return x
+	case y.IsInf():
+		return y
+	}
+	if !align(&x, &y) {
+		return x
+	}
+	if x.sign != y.sign {
+		return usub(x, y)
+	}
+	return uadd(x, y)
+}
+
+func (x Value) Add(y Value) Value {
+	return Add(x, y)
+}
+
+func uadd(x, y Value) Value {
+	return New(x.sign, x.coef+y.coef, int(x.exp))
+}
+
+func usub(x, y Value) Value {
+	if x.coef < y.coef {
+		return New(-x.sign, y.coef-x.coef, int(x.exp))
+	}
+	return New(x.sign, x.coef-y.coef, int(x.exp))
+}
+
+func align(x, y *Value) bool {
+	if x.exp == y.exp {
+		return true
+	}
+	if x.exp < y.exp {
+		*x, *y = *y, *x // swap
+	}
+	yshift := ilog10(y.coef)
+	e := int(x.exp - y.exp)
+	if e > yshift {
+		return false
+	}
+	yshift = e
+	// check(0 <= yshift && yshift <= 20)
+	//y.coef = (y.coef + halfpow10[yshift]) / pow10[yshift]
+	y.coef = (y.coef) / pow10[yshift]
+	// check(int(y.exp)+yshift == int(x.exp))
+	return true
+}
+
+const e7 = 10000000
+
+// Mul returns the product of two Value's
+func Mul(x, y Value) Value {
+	sign := x.sign * y.sign
+	switch {
+	case sign == signZero:
+		return Zero
+	case x.IsInf() || y.IsInf():
+		return Inf(sign)
+	}
+	e := int(x.exp) + int(y.exp)
+
+	// split unevenly to use full 64 bit range to get more precision
+	// and avoid needing xlo * ylo
+	xhi := x.coef / e7 // 9 digits
+	xlo := x.coef % e7 // 7 digits
+	yhi := y.coef / e7 // 9 digits
+	ylo := y.coef % e7 // 7 digits
+
+	c := xhi * yhi
+	if (xlo | ylo) != 0 {
+		c += (xlo*yhi + ylo*xhi) / e7
+	}
+	return New(sign, c, e-2)
+}
+
+func (x Value) Mul(y Value) Value {
+	return Mul(x, y)
+}
+
+// Div returns the quotient of two Value's
+func Div(x, y Value) Value {
+	sign := x.sign * y.sign
+	switch {
+	case x.sign == signZero:
+		return x
+	case y.sign == signZero:
+		return Inf(x.sign)
+	case x.IsInf():
+		if y.IsInf() {
+			if sign < 0 {
+				return NegOne
+			}
+			return One
+		}
+		return Inf(sign)
+	case y.IsInf():
+		return Zero
+	}
+	coef := div128(x.coef, y.coef)
+	return New(sign, coef, int(x.exp)-int(y.exp))
+}
+
+func (x Value) Div(y Value) Value {
+	return Div(x, y)
+}
+
+// Hash returns a hash value for a Value
+func (dn Value) Hash() uint32 {
+	return uint32(dn.coef>>32) ^ uint32(dn.coef) ^
+		uint32(dn.sign)<<16 ^ uint32(dn.exp)<<8
+}
+
+// Format converts a number to a string with a specified format
+func (dn Value) Format(mask string) string {
+	if dn.IsInf() {
+		return "#"
+	}
+	n := dn
+	before := 0
+	after := 0
+	intpart := true
+	for _, mc := range mask {
+		switch mc {
+		case '.':
+			intpart = false
+		case '#':
+			if intpart {
+				before++
+			} else {
+				after++
+			}
+		}
+	}
+	if before+after == 0 || n.Exp() > before {
+		return "#" // too big to fit in mask
+	}
+	n = n.Round(after, HalfUp)
+	e := n.Exp()
+	var digits []byte
+	if n.IsZero() && after == 0 {
+		digits = []byte("0")
+		e = 1
+	} else {
+		digits = strconv.AppendUint(make([]byte, 0, digitsMax), n.Coef(), 10)
+		digits = bytes.TrimRight(digits, "0")
+	}
+	nd := len(digits)
+
+	di := e - before
+	// check(di <= 0)
+	var buf strings.Builder
+	sign := n.Sign()
+	signok := (sign >= 0)
+	frac := false
+	for _, mc := range []byte(mask) {
+		switch mc {
+		case '#':
+			if 0 <= di && di < nd {
+				buf.WriteByte(digits[di])
+			} else if frac || di >= 0 {
+				buf.WriteByte('0')
+			}
+			di++
+		case ',':
+			if di > 0 {
+				buf.WriteByte(',')
+			}
+		case '-', '(':
+			signok = true
+			if sign < 0 {
+				buf.WriteByte(mc)
+			}
+		case ')':
+			if sign < 0 {
+				buf.WriteByte(mc)
+			} else {
+				buf.WriteByte(' ')
+			}
+		case '.':
+			frac = true
+			fallthrough
+		default:
+			buf.WriteByte(mc)
+		}
+	}
+	if !signok {
+		return "-" // negative not handled by mask
+	}
+	return buf.String()
+}
+
+func Clamp(x, min, max Value) Value {
+	if x.Compare(min) < 0 {
+		return min
+	}
+	if x.Compare(max) > 0 {
+		return max
+	}
+	return x
+}
+
+func (x Value) Clamp(min, max Value) Value {
+	if x.Compare(min) < 0 {
+		return min
+	}
+	if x.Compare(max) > 0 {
+		return max
+	}
+	return x
+}

--- a/cDec/dec_dnum_test.go
+++ b/cDec/dec_dnum_test.go
@@ -1,0 +1,44 @@
+//go:build dnum
+
+package cDec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDelta(t *testing.T) {
+	f1 := MustNewFromString("0.0009763593380614657")
+	f2 := NewFromInt(42300)
+	assert.InDelta(t, f1.Mul(f2).Float64(), 41.3, 1e-14)
+}
+
+func TestFloor(t *testing.T) {
+	f1 := MustNewFromString("10.333333")
+	f2 := f1.Floor()
+	assert.Equal(t, "10", f2.String())
+}
+
+func TestInternal(t *testing.T) {
+	r := &reader{"1.1e-15", 0}
+	c, e := r.getCoef()
+	assert.Equal(t, uint64(1100000000000000), c)
+	assert.Equal(t, 1, e)
+	f := MustNewFromString("1.1e-15")
+	digits := getDigits(f.coef)
+	assert.Equal(t, "11", digits)
+	f = MustNewFromString("1.00000000000000111")
+	assert.Equal(t, "1.000000000000001", f.String())
+	f = MustNewFromString("1.1e-15")
+	assert.Equal(t, "0.0000000000000011", f.String())
+	assert.Equal(t, 16, f.NumFractionalDigits())
+	f = MustNewFromString("1.00000000000000111")
+	assert.Equal(t, "1.000000000000001", f.String())
+	f = MustNewFromString("0.00000000000000000001000111")
+	assert.Equal(t, "0.00000000000000000001000111", f.String())
+	f = MustNewFromString("0.000000000000000000001000111")
+	assert.Equal(t, "1.000111e-21", f.String())
+	f = MustNewFromString("1e-100")
+	assert.Equal(t, 100, f.NumFractionalDigits())
+}

--- a/cDec/dec_legacy_test.go
+++ b/cDec/dec_legacy_test.go
@@ -1,0 +1,33 @@
+//go:build !dnum
+
+package cDec
+
+import (
+	"testing"
+)
+
+func TestNumFractionalDigitsLegacy(t *testing.T) {
+	tests := []struct {
+		name string
+		v    Value
+		want int
+	}{
+		{
+			name: "over the default precision",
+			v:    MustNewFromString("0.123456789"),
+			want: 8,
+		},
+		{
+			name: "zero underflow",
+			v:    MustNewFromString("1e-100"),
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.v.NumFractionalDigits(); got != tt.want {
+				t.Errorf("NumFractionalDigitsLegacy() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cDec/dec_test.go
+++ b/cDec/dec_test.go
@@ -1,0 +1,304 @@
+package cDec
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+const Delta = 1e-9
+
+func BenchmarkMul(b *testing.B) {
+	b.ResetTimer()
+
+	b.Run("mul-float64", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			x := NewFromFloat(20.0)
+			y := NewFromFloat(20.0)
+			x = x.Mul(y) // nolint
+		}
+	})
+
+	b.Run("mul-float64-large-numbers", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			x := NewFromFloat(88.12345678)
+			y := NewFromFloat(88.12345678)
+			x = x.Mul(y) // nolint
+		}
+	})
+
+	b.Run("mul-big-small-numbers", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			x := big.NewFloat(20.0)
+			y := big.NewFloat(20.0)
+			x = new(big.Float).Mul(x, y) // nolint
+		}
+	})
+
+	b.Run("mul-big-large-numbers", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			x := big.NewFloat(88.12345678)
+			y := big.NewFloat(88.12345678)
+			x = new(big.Float).Mul(x, y) // nolint
+		}
+	})
+}
+
+func TestMulString(t *testing.T) {
+	x := NewFromFloat(10.55)
+	assert.Equal(t, "10.55", x.String())
+	y := NewFromFloat(10.55)
+	x = x.Mul(y)
+	assert.Equal(t, "111.3025", x.String())
+	assert.Equal(t, "111.30", x.FormatString(2))
+	assert.InDelta(t, 111.3025, x.Float64(), Delta)
+}
+
+func TestMulExp(t *testing.T) {
+	x, _ := NewFromString("166")
+	digits := x.NumIntDigits()
+	assert.Equal(t, digits, 3)
+	step := x.MulExp(-digits + 1)
+	assert.Equal(t, "1.66", step.String())
+}
+
+func TestNew(t *testing.T) {
+	f := NewFromFloat(0.001)
+	assert.Equal(t, "0.001", f.String())
+	assert.Equal(t, "0.0010", f.FormatString(4))
+	assert.Equal(t, "0.1%", f.Percentage())
+	assert.Equal(t, "0.10%", f.FormatPercentage(2))
+	f = NewFromFloat(0.1)
+	assert.Equal(t, "10%", f.Percentage())
+	assert.Equal(t, "10%", f.FormatPercentage(0))
+	f = NewFromFloat(0.01)
+	assert.Equal(t, "1%", f.Percentage())
+	assert.Equal(t, "1%", f.FormatPercentage(0))
+	f = NewFromFloat(0.111)
+	assert.Equal(t, "11.1%", f.Percentage())
+	assert.Equal(t, "11.1%", f.FormatPercentage(1))
+}
+
+func TestFormatString(t *testing.T) {
+	testCases := []struct {
+		value Value
+		prec  int
+		out   string
+	}{
+		{
+			value: NewFromFloat(0.001),
+			prec:  8,
+			out:   "0.00100000",
+		},
+		{
+			value: NewFromFloat(0.123456789),
+			prec:  4,
+			out:   "0.1234",
+		},
+		{
+			value: NewFromFloat(0.123456789),
+			prec:  5,
+			out:   "0.12345",
+		},
+		{
+			value: NewFromFloat(20.0),
+			prec:  0,
+			out:   "20",
+		},
+	}
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.out, testCase.value.FormatString(testCase.prec))
+	}
+}
+
+func TestRound(t *testing.T) {
+	f := NewFromFloat(1.2345)
+	f = f.Round(0, Down)
+	assert.Equal(t, "1", f.String())
+	w := NewFromFloat(1.2345)
+	w = w.Trunc()
+	assert.Equal(t, "1", w.String())
+	s := NewFromFloat(1.2345)
+	assert.Equal(t, "1.23", s.Round(2, Down).String())
+}
+
+func TestNewFromString(t *testing.T) {
+	f, err := NewFromString("0.00000003")
+	assert.NoError(t, err)
+	assert.Equal(t, "0.00000003", f.String())
+}
+
+func TestFromString(t *testing.T) {
+	f := MustNewFromString("0.004075")
+	assert.Equal(t, "0.004075", f.String())
+	f = MustNewFromString("0.03")
+	assert.Equal(t, "0.03", f.String())
+
+	f = MustNewFromString("0.75%")
+	assert.Equal(t, "0.0075", f.String())
+	f = MustNewFromString("1.1e-7")
+	assert.Equal(t, "0.00000011", f.String())
+	f = MustNewFromString(".0%")
+	assert.Equal(t, Zero, f)
+	f = MustNewFromString("")
+	assert.Equal(t, Zero, f)
+
+	for _, s := range []string{"inf", "Inf", "INF", "iNF"} {
+		f = MustNewFromString(s)
+		assert.Equal(t, PosInf, f)
+		f = MustNewFromString("+" + s)
+		assert.Equal(t, PosInf, f)
+		f = MustNewFromString("-" + s)
+		assert.Equal(t, NegInf, f)
+	}
+}
+
+func TestJson(t *testing.T) {
+	p := MustNewFromString("0")
+	e, err := json.Marshal(p)
+	assert.NoError(t, err)
+	assert.Equal(t, "0.00000000", string(e))
+	p = MustNewFromString("1.00000003")
+	e, err = json.Marshal(p)
+	assert.NoError(t, err)
+	assert.Equal(t, "1.00000003", string(e))
+	p = MustNewFromString("1.000000003")
+	e, err = json.Marshal(p)
+	assert.NoError(t, err)
+	assert.Equal(t, "1.00000000", string(e))
+	p = MustNewFromString("1.000000008")
+	e, err = json.Marshal(p)
+	assert.NoError(t, err)
+	assert.Equal(t, "1.00000000", string(e))
+	p = MustNewFromString("0.999999999")
+	e, err = json.Marshal(p)
+	assert.NoError(t, err)
+	assert.Equal(t, "0.99999999", string(e))
+
+	p = MustNewFromString("1.2e-9")
+	e, err = json.Marshal(p)
+	assert.NoError(t, err)
+	assert.Equal(t, "0.00000000", p.FormatString(8))
+	assert.Equal(t, "0.00000000", string(e))
+
+	_ = json.Unmarshal([]byte("0.00153917575"), &p)
+	assert.Equal(t, "0.00153917", p.FormatString(8))
+
+	q := NewFromFloat(0.00153917575)
+	assert.Equal(t, p, q)
+	_ = json.Unmarshal([]byte("6e-8"), &p)
+	_ = json.Unmarshal([]byte("0.000062"), &q)
+	assert.Equal(t, "0.00006194", q.Sub(p).String())
+
+	assert.NoError(t, json.Unmarshal([]byte(`"inf"`), &p))
+	assert.NoError(t, json.Unmarshal([]byte(`"+Inf"`), &q))
+	assert.Equal(t, PosInf, p)
+	assert.Equal(t, p, q)
+}
+
+func TestYaml(t *testing.T) {
+	p := MustNewFromString("0")
+	e, err := yaml.Marshal(p)
+	assert.NoError(t, err)
+	assert.Equal(t, "\"0.00000000\"\n", string(e))
+	p = MustNewFromString("1.00000003")
+	e, err = yaml.Marshal(p)
+	assert.NoError(t, err)
+	assert.Equal(t, "\"1.00000003\"\n", string(e))
+	p = MustNewFromString("1.000000003")
+	e, err = yaml.Marshal(p)
+	assert.NoError(t, err)
+	assert.Equal(t, "\"1.00000000\"\n", string(e))
+	p = MustNewFromString("1.000000008")
+	e, err = yaml.Marshal(p)
+	assert.NoError(t, err)
+	assert.Equal(t, "\"1.00000000\"\n", string(e))
+	p = MustNewFromString("0.999999999")
+	e, err = yaml.Marshal(p)
+	assert.NoError(t, err)
+	assert.Equal(t, "\"0.99999999\"\n", string(e))
+
+	p = MustNewFromString("1.2e-9")
+	e, err = yaml.Marshal(p)
+	assert.NoError(t, err)
+	assert.Equal(t, "0.00000000", p.FormatString(8))
+	assert.Equal(t, "\"0.00000000\"\n", string(e))
+
+	_ = yaml.Unmarshal([]byte("0.00153917575"), &p)
+	assert.Equal(t, "0.00153917", p.FormatString(8))
+
+	q := NewFromFloat(0.00153917575)
+	assert.Equal(t, p, q)
+	_ = yaml.Unmarshal([]byte("6e-8"), &p)
+	_ = yaml.Unmarshal([]byte("0.000062"), &q)
+	assert.Equal(t, "0.00006194", q.Sub(p).String())
+
+	assert.NoError(t, json.Unmarshal([]byte(`"inf"`), &p))
+	assert.NoError(t, json.Unmarshal([]byte(`"+Inf"`), &q))
+	assert.Equal(t, PosInf, p)
+	assert.Equal(t, p, q)
+}
+
+func TestNumFractionalDigits(t *testing.T) {
+	tests := []struct {
+		name string
+		v    Value
+		want int
+	}{
+		{
+			name: "ignore the integer part",
+			v:    MustNewFromString("123.4567"),
+			want: 4,
+		},
+		{
+			name: "ignore the sign",
+			v:    MustNewFromString("-123.4567"),
+			want: 4,
+		},
+		{
+			name: "ignore the trailing zero",
+			v:    MustNewFromString("-123.45000000"),
+			want: 2,
+		},
+		{
+			name: "no fractional parts",
+			v:    MustNewFromString("-1"),
+			want: 0,
+		},
+		{
+			name: "no fractional parts",
+			v:    MustNewFromString("-1.0"),
+			want: 0,
+		},
+		{
+			name: "only fractional part",
+			v:    MustNewFromString(".123456"),
+			want: 6,
+		},
+		{
+			name: "percentage",
+			v:    MustNewFromString("0.075%"), // 0.075 * 0.01
+			want: 5,
+		},
+		{
+			name: "scientific notation",
+			v:    MustNewFromString("1.1e-7"),
+			want: 8,
+		},
+		{
+			name: "zero",
+			v:    MustNewFromString("0"),
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.v.NumFractionalDigits(); got != tt.want {
+				t.Errorf("NumFractionalDigits() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cDec/helpers.go
+++ b/cDec/helpers.go
@@ -1,0 +1,15 @@
+package cDec
+
+func Sum(values []Value) (s Value) {
+	s = Zero
+	for _, value := range values {
+		s = s.Add(value)
+	}
+	return s
+}
+
+func Avg(values []Value) (avg Value) {
+	s := Sum(values)
+	avg = s.Div(NewFromInt(int64(len(values))))
+	return avg
+}

--- a/cDec/reduce.go
+++ b/cDec/reduce.go
@@ -1,0 +1,25 @@
+package cDec
+
+type Reducer func(prev, curr Value) Value
+
+func SumReducer(prev, curr Value) Value {
+	return prev.Add(curr)
+}
+
+func Reduce(values []Value, reducer Reducer, a ...Value) Value {
+	init := Zero
+	if len(a) > 0 {
+		init = a[0]
+	}
+
+	if len(values) == 0 {
+		return init
+	}
+
+	r := reducer(init, values[0])
+	for i := 1; i < len(values); i++ {
+		r = reducer(r, values[i])
+	}
+
+	return r
+}

--- a/cDec/reduce_test.go
+++ b/cDec/reduce_test.go
@@ -1,0 +1,37 @@
+package cDec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReduce(t *testing.T) {
+	type args struct {
+		values  []Value
+		init    Value
+		reducer Reducer
+	}
+	tests := []struct {
+		name string
+		args args
+		want Value
+	}{
+		{
+			name: "simple",
+			args: args{
+				values: []Value{NewFromFloat(1), NewFromFloat(2), NewFromFloat(3)},
+				init:   NewFromFloat(0.0),
+				reducer: func(prev, curr Value) Value {
+					return prev.Add(curr)
+				},
+			},
+			want: NewFromFloat(6),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, Reduce(tt.args.values, tt.args.reducer, tt.args.init), "Reduce(%v, %v, %v)", tt.args.values, tt.args.init, tt.args.reducer)
+		})
+	}
+}

--- a/cDec/slice.go
+++ b/cDec/slice.go
@@ -1,0 +1,24 @@
+package cDec
+
+type Slice []Value
+
+func (s Slice) Reduce(reducer Reducer, a ...Value) Value {
+	return Reduce(s, reducer, a...)
+}
+
+// Defaults to ascending sort
+func (s Slice) Len() int           { return len(s) }
+func (s Slice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s Slice) Less(i, j int) bool { return s[i].Compare(s[j]) < 0 }
+
+type Ascending []Value
+
+func (s Ascending) Len() int           { return len(s) }
+func (s Ascending) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s Ascending) Less(i, j int) bool { return s[i].Compare(s[j]) < 0 }
+
+type Descending []Value
+
+func (s Descending) Len() int           { return len(s) }
+func (s Descending) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s Descending) Less(i, j int) bool { return s[i].Compare(s[j]) > 0 }

--- a/cDec/slice_test.go
+++ b/cDec/slice_test.go
@@ -1,0 +1,35 @@
+package cDec
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortInterface(t *testing.T) {
+	slice := Slice{
+		NewFromInt(7),
+		NewFromInt(3),
+		NewFromInt(1),
+		NewFromInt(2),
+		NewFromInt(5),
+	}
+	sort.Sort(slice)
+	assert.Equal(t, "1", slice[0].String())
+	assert.Equal(t, "2", slice[1].String())
+	assert.Equal(t, "3", slice[2].String())
+	assert.Equal(t, "5", slice[3].String())
+
+	sort.Sort(Descending(slice))
+	assert.Equal(t, "7", slice[0].String())
+	assert.Equal(t, "5", slice[1].String())
+	assert.Equal(t, "3", slice[2].String())
+	assert.Equal(t, "2", slice[3].String())
+
+	sort.Sort(Ascending(slice))
+	assert.Equal(t, "1", slice[0].String())
+	assert.Equal(t, "2", slice[1].String())
+	assert.Equal(t, "3", slice[2].String())
+	assert.Equal(t, "5", slice[3].String())
+}


### PR DESCRIPTION
![dc303ad8-8899-4e4a-a065-73f94e381799](https://github.com/EasyGolang/goTools/assets/17699910/8fb968e9-c5c3-4d6b-9b5e-e59d52d65f4f)
一个decimal的替代方案。在工程下的的cDec包，包含测试用例。压测效果提升明显

